### PR TITLE
Change rls -> rls-preview, use stable toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
  - Go to definition (`ctrl` or `cmd` click)
  - Type information and Documentation on hover (hold `ctrl` or `cmd` for more information)
 
+### Toolchain
+
+`ide-rust` will use your default toolchain if you have one, or install the `stable` toolchain and set that as default otherwise.
+
+RLS requires a toolchain with version at least 1.21.
+
 ## Install
 
 You can install from the command line with:

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ function checkRls() {
   return exec("rustup component list --toolchain nightly").then(results => {
     const { stdout } = results
     if (
-      stdout.search(/^rls.* \((default|installed)\)$/m) >= 0 &&
+      stdout.search(/^rls-preview.* \((default|installed)\)$/m) >= 0 &&
       stdout.search(/^rust-analysis.* \((default|installed)\)$/m) >= 0 &&
       stdout.search(/^rust-src.* \((default|installed)\)$/m) >= 0
     ) {
@@ -132,7 +132,7 @@ function checkRls() {
     }
 
     // Don't have RLS
-    return exec("rustup component add rls --toolchain nightly")
+    return exec("rustup component add rls-preview --toolchain nightly")
       .then(() => exec("rustup component add rust-src --toolchain nightly"))
       .then(() =>
         exec("rustup component add rust-analysis --toolchain nightly")

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,36 +55,40 @@ function installRustup() {
   return exec("curl https://sh.rustup.rs -sSf | sh -s -- -y")
 }
 
-// Installs nightly
-function installNightly() {
-  return exec("rustup toolchain install nightly")
+function installStable() {
+  return exec("rustup toolchain install stable")
 }
 
-// Checks for rustup and nightly toolchain
+function setDefaultToolchain() {
+  return exec("rustup default stable")
+}
+
+// Checks for rustup and a default toolchain
 // If not found, asks to install. If user declines, throws error
 function checkToolchain() {
   return new Promise((resolve, reject) => {
     exec("rustup toolchain list")
       .then(results => {
         const { stdout } = results
-        const matches = /^(?=nightly)(.*)$/im.exec(stdout)
+        const matches = /(.*) \(default\)$/im.exec(stdout)
 
-        // If found, we're done
-        if (matches) {
-          return resolve(matches[0])
+        // If default toolchain found, we're done
+        if (matches && matches.length > 1) {
+          return resolve(matches[1])
         }
 
-        // If not found, install it
+        // If no default toolchain found, install stable toolchain
         // Ask to install
         atomPrompt(
-          "`rustup` missing nightly toolchain",
+          "`rustup` missing default toolchain",
           {
-            detail: "rustup toolchain install nightly"
+            detail: "rustup toolchain install stable && rustup default stable"
           },
           ["Install"]
         ).then(response => {
           if (response === "Install") {
-            installNightly()
+            installStable()
+              .then(() => setDefaultToolchain())
               .then(checkToolchain)
               .then(resolve)
               .catch(reject)
@@ -120,7 +124,7 @@ function checkToolchain() {
 
 // Check for and install RLS
 function checkRls() {
-  return exec("rustup component list --toolchain nightly").then(results => {
+  return exec("rustup component list").then(results => {
     const { stdout } = results
     if (
       stdout.search(/^rls-preview.* \((default|installed)\)$/m) >= 0 &&
@@ -132,11 +136,17 @@ function checkRls() {
     }
 
     // Don't have RLS
-    return exec("rustup component add rls-preview --toolchain nightly")
-      .then(() => exec("rustup component add rust-src --toolchain nightly"))
+    return exec("rustup component add rls-preview")
+      .then(() => exec("rustup component add rust-src"))
       .then(() =>
-        exec("rustup component add rust-analysis --toolchain nightly")
+        exec("rustup component add rust-analysis")
       )
+  })
+  .catch(() => {
+    atom.notifications.addError("Unable to install RLS components", {
+      dismissable: true,
+      detail: "Please ensure your default toolchain is at least version 1.21"
+    })
   })
 }
 
@@ -175,7 +185,7 @@ class RustLanguageClient extends AutoLanguageClient {
           )
         }
 
-        return cp.spawn("rustup", ["run", "nightly", "rls"], {
+        return cp.spawn("rustup", ["run", "rls"], {
           env: {
             PATH: getPath(),
             RUST_SRC_PATH: rustSrcPath


### PR DESCRIPTION
The rls component has been [renamed to rls-preview](https://github.com/rust-lang-nursery/rls/blob/master/README.md#step-3-install-the-rls).