### PR TITLE
Revert "Use default toolchain if present, stable otherwise"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@
  - Go to definition (`ctrl` or `cmd` click)
  - Type information and Documentation on hover (hold `ctrl` or `cmd` for more information)
 
-### Toolchain
-
-`ide-rust` will use your default toolchain if you have one, or install the `stable` toolchain and set that as default otherwise.
-
-RLS requires a toolchain with version at least 1.21.
-
 ## Install
 
 You can install from the command line with:

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,40 +55,36 @@ function installRustup() {
   return exec("curl https://sh.rustup.rs -sSf | sh -s -- -y")
 }
 
-function installStable() {
-  return exec("rustup toolchain install stable")
+// Installs nightly
+function installNightly() {
+  return exec("rustup toolchain install nightly")
 }
 
-function setDefaultToolchain() {
-  return exec("rustup default stable")
-}
-
-// Checks for rustup and a default toolchain
+// Checks for rustup and nightly toolchain
 // If not found, asks to install. If user declines, throws error
 function checkToolchain() {
   return new Promise((resolve, reject) => {
     exec("rustup toolchain list")
       .then(results => {
         const { stdout } = results
-        const matches = /(.*) \(default\)$/im.exec(stdout)
+        const matches = /^(?=nightly)(.*)$/im.exec(stdout)
 
-        // If default toolchain found, we're done
-        if (matches && matches.length > 1) {
-          return resolve(matches[1])
+        // If found, we're done
+        if (matches) {
+          return resolve(matches[0])
         }
 
-        // If no default toolchain found, install stable toolchain
+        // If not found, install it
         // Ask to install
         atomPrompt(
-          "`rustup` missing default toolchain",
+          "`rustup` missing nightly toolchain",
           {
-            detail: "rustup toolchain install stable && rustup default stable"
+            detail: "rustup toolchain install nightly"
           },
           ["Install"]
         ).then(response => {
           if (response === "Install") {
-            installStable()
-              .then(() => setDefaultToolchain())
+            installNightly()
               .then(checkToolchain)
               .then(resolve)
               .catch(reject)
@@ -124,7 +120,7 @@ function checkToolchain() {
 
 // Check for and install RLS
 function checkRls() {
-  return exec("rustup component list").then(results => {
+  return exec("rustup component list --toolchain nightly").then(results => {
     const { stdout } = results
     if (
       stdout.search(/^rls-preview.* \((default|installed)\)$/m) >= 0 &&
@@ -136,17 +132,11 @@ function checkRls() {
     }
 
     // Don't have RLS
-    return exec("rustup component add rls-preview")
-      .then(() => exec("rustup component add rust-src"))
+    return exec("rustup component add rls-preview --toolchain nightly")
+      .then(() => exec("rustup component add rust-src --toolchain nightly"))
       .then(() =>
-        exec("rustup component add rust-analysis")
+        exec("rustup component add rust-analysis --toolchain nightly")
       )
-  })
-  .catch(() => {
-    atom.notifications.addError("Unable to install RLS components", {
-      dismissable: true,
-      detail: "Please ensure your default toolchain is at least version 1.21"
-    })
   })
 }
 
@@ -185,7 +175,7 @@ class RustLanguageClient extends AutoLanguageClient {
           )
         }
 
-        return cp.spawn("rustup", ["run", "rls"], {
+        return cp.spawn("rustup", ["run", "nightly", "rls"], {
           env: {
             PATH: getPath(),
             RUST_SRC_PATH: rustSrcPath


### PR DESCRIPTION
Despite installing and appearing to run correctly, rls-preview doesn't work on stable despite being 1.21. I think we should just revert my commit from yesterday until that changes. Very sorry for not realizing the issues before creating the PR, my fault.

This reverts commit dd3722dbebaa541d4361f05abdc7d19e00ea5834.

Fixes #10 