### PR TITLE
Add Rls configuration using project `rls.toml` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
  - Document outline
  - Go to definition (`ctrl` or `cmd` click)
  - Type information and Documentation on hover (hold `ctrl` or `cmd` for more information)
+ - Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
 
 ## Install
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,9 @@
 const cp = require("child_process")
 const os = require("os")
 const path = require("path")
+const _ = require('lodash')
+const RlsProject = require('./rls-project.js')
+const { CompositeDisposable } = require('atom')
 const { AutoLanguageClient } = require("atom-languageclient")
 
 // TODO: Support windows
@@ -141,11 +144,47 @@ function checkRls() {
 }
 
 class RustLanguageClient extends AutoLanguageClient {
+  constructor() {
+    super()
+    /** (projectPath -> RlsProject) mappings */
+    this.projects = {}
+    this.disposables = new CompositeDisposable()
+  }
+
   activate() {
     super.activate()
 
     // Get required dependencies
     require("atom-package-deps").install("ide-rust", false)
+
+    this.disposables.add(atom.project.onDidChangeFiles(events => {
+      if (_.isEmpty(this.projects)) return
+
+      for (const event of events) {
+        if (event.path.endsWith('rls.toml')) {
+          let projectPath = Object.keys(this.projects).find(key => event.path.startsWith(key))
+          let rlsProject = projectPath && this.projects[projectPath]
+          if (rlsProject) rlsProject.sendRlsTomlConfig()
+        }
+      }
+    }))
+  }
+
+  deactivate() {
+    super.deactivate()
+    this.disposables.dispose()
+  }
+
+  postInitialization(server) {
+    // track the server so we can keep its config updated
+    let project = new RlsProject(server)
+    this.projects[server.projectPath] = project
+
+    server.process.on('exit', () => {
+      delete this.projects[server.projectPath]
+    })
+
+    project.sendRlsTomlConfig()
   }
 
   getGrammarScopes() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const cp = require("child_process")
 const os = require("os")
 const path = require("path")
-const _ = require('lodash')
+const _ = require('underscore-plus')
 const RlsProject = require('./rls-project.js')
 const { CompositeDisposable } = require('atom')
 const { AutoLanguageClient } = require("atom-languageclient")

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -1,7 +1,7 @@
 const path = require("path")
 const fs = require('fs')
 const toml = require('toml')
-const _ = require('lodash')
+const _ = require('underscore-plus')
 
 /** Container for references to a single Rls invocation */
 class RlsProject {

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -1,0 +1,33 @@
+const path = require("path")
+const fs = require('fs')
+const toml = require('toml')
+const _ = require('lodash')
+
+/** Container for references to a single Rls invocation */
+class RlsProject {
+  constructor(server) {
+    this.server = server
+    this.lastSentConfig = {}
+  }
+
+  sendRlsTomlConfig() {
+    let rlsTomlPath = path.join(this.server.projectPath, 'rls.toml')
+
+    fs.readFile(rlsTomlPath, (err, data) => {
+      if (err) return
+
+      try {
+        let config = toml.parse(data)
+        if (_.isEqual(config, this.lastSentConfig)) return
+
+        this.server.connection.didChangeConfiguration({
+          settings: { rust: config }
+        })
+        this.lastSentConfig = config
+      }
+      catch (e) { console.warn(`Failed to read ${rlsTomlPath}`, e) }
+    })
+  }
+}
+
+module.exports = RlsProject

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,11 +44,6 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -114,6 +109,19 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      }
     },
     "vscode-jsonrpc": {
       "version": "3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "ide-rust",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "atom-languageclient": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.6.4.tgz",
-      "integrity": "sha1-aCB5hign8p+zIcwoyHdUOfYXVKI=",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.6.5.tgz",
+      "integrity": "sha1-dgyy4DbXHqhQkKwSPV/GyCn9Rkk=",
       "requires": {
         "vscode-jsonrpc": "3.4.1"
       }
@@ -43,6 +43,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -104,6 +109,11 @@
       "requires": {
         "is-utf8": "0.2.1"
       }
+    },
+    "toml": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
     "vscode-jsonrpc": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "atom-languageclient": "^0.6.5",
     "atom-package-deps": "^4.6.0",
-    "lodash": "^4.17.4",
-    "toml": "^2.3.3"
+    "toml": "^2.3.3",
+    "underscore-plus": "^1.6.6"
   },
   "enhancedScopes": [
     "source.rust"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.6.4",
-    "atom-package-deps": "^4.6.0"
+    "atom-languageclient": "^0.6.5",
+    "atom-package-deps": "^4.6.0",
+    "lodash": "^4.17.4",
+    "toml": "^2.3.3"
   },
   "enhancedScopes": [
     "source.rust"


### PR DESCRIPTION
We will now watch `rls.toml` files in the project roots, if present on open or changed we'll send *DidChangeConfiguration* messages to rls derived from the contents.

After all that I found rls workspaces didn't work for me anyway, presumably as they're still a work in progress. But I think being able to config rls in this way is a useful addition in any case.

### Implementation notes
I added `lodash` and `toml` dependency. The former isn't *heavily* used, so if you have a different preference it'll be easy to change. I tried to adopt your *no-semi-colons-allowed* style, which felt wrong. I had to delete many semi colons I couldn't prevent myself from typing.

Resolves  #13