### PR TITLE
Use filterChangeWatchedFiles to reduce watch message spam

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,13 @@ class RustLanguageClient extends AutoLanguageClient {
     return "RLS"
   }
 
+  filterChangeWatchedFiles(filePath) {
+    // TODO ignore all files and wait for `client/registerCapability`
+    // to inform us of the correct files to watch, until that's implemented
+    // these filters take eliminate the brunt of the watch message spam
+    return !filePath.includes('/.git/') && !filePath.includes('/target/rls/')
+  }
+
   startServerProcess() {
     let toolchain
     return checkToolchain()

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "atom-languageclient": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.6.5.tgz",
-      "integrity": "sha1-dgyy4DbXHqhQkKwSPV/GyCn9Rkk=",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.6.6.tgz",
+      "integrity": "sha1-KDnop4nmF4nMjaM8Awdg+esTG80=",
       "requires": {
         "vscode-jsonrpc": "3.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.6.5",
+    "atom-languageclient": "^0.6.6",
     "atom-package-deps": "^4.6.0",
     "toml": "^2.3.3",
     "underscore-plus": "^1.6.6"


### PR DESCRIPTION
By taking advantage of the new `filterChangeWatchedFiles` method in atom-languageclient:0.6.6 we can solve the immediate watch-message spam issue by ignoring target/rls & .git files.

Actually rls is expecting an `initialized` notification, to which it will request `client/registerCapability` telling us which files we should watch. So ideally we should filter out ***all*** didChangeWatchedFiles until we've received which files are required (currently just Cargo.toml, Cargo.lock and target/).

However, since sending a `initialized` notification & handling `client/registerCapability` requests are currently not in atom-languageclient I think its best to put a plaster on this for now (with a healthy *TODO*) and tackle handling that stuff later.