### PR TITLE
Urgent fix: Use filterChangeWatchedFiles hook to avoid infinite change loop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,18 +156,6 @@ class RustLanguageClient extends AutoLanguageClient {
 
     // Get required dependencies
     require("atom-package-deps").install("ide-rust", false)
-
-    this.disposables.add(atom.project.onDidChangeFiles(events => {
-      if (_.isEmpty(this.projects)) return
-
-      for (const event of events) {
-        if (event.path.endsWith('rls.toml')) {
-          let projectPath = Object.keys(this.projects).find(key => event.path.startsWith(key))
-          let rlsProject = projectPath && this.projects[projectPath]
-          if (rlsProject) rlsProject.sendRlsTomlConfig()
-        }
-      }
-    }))
   }
 
   deactivate() {
@@ -221,6 +209,19 @@ class RustLanguageClient extends AutoLanguageClient {
           }
         })
       })
+  }
+
+  filterChangeWatchedFiles(filePath) {
+    for (const projectPath in this.projects) {
+      if (filePath.startsWith(projectPath)) {
+        const project = this.projects[projectPath]
+        if (filePath.startsWith(project.projectTargetPath)) return false
+        if (filePath.startsWith(project.projectDotGitPath)) return false
+        if (filePath === project.rlsTomlPath) project.sendRlsTomlConfig()
+        return true
+      }
+    }
+    return false
   }
 }
 

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -7,13 +7,14 @@ const _ = require('underscore-plus')
 class RlsProject {
   constructor(server) {
     this.server = server
+    this.rlsTomlPath = path.join(this.server.projectPath, 'rls.toml')
+    this.projectTargetPath = path.join(this.server.projectPath, 'target')
+    this.projectDotGitPath = path.join(this.server.projectPath, '.git')
     this.lastSentConfig = {}
   }
 
   sendRlsTomlConfig() {
-    let rlsTomlPath = path.join(this.server.projectPath, 'rls.toml')
-
-    fs.readFile(rlsTomlPath, (err, data) => {
+    fs.readFile(this.rlsTomlPath, (err, data) => {
       if (err) return
 
       try {
@@ -25,7 +26,7 @@ class RlsProject {
         })
         this.lastSentConfig = config
       }
-      catch (e) { console.warn(`Failed to read ${rlsTomlPath}`, e) }
+      catch (e) { console.warn(`Failed to read ${this.rlsTomlPath}`, e) }
     })
   }
 }


### PR DESCRIPTION
**tl;dr** The changes in this PR are required for this package to be usable on my machine.

Currently, if you enable logging on `atom-languageclient` via `atom.config.set('core.debugLSP', true)` and reload, this is what you see on startup.

![watch-loop](https://user-images.githubusercontent.com/1789/32414537-9f8c8d0a-c1e6-11e7-8251-586ced9cc405.gif)

It seems that we're getting into an endless loop. We detect the language server's own changes writing to a subdirectory of the project's `target` folder, then send those changes to the language server, which triggers another build and more writes, etc...

This PR makes use of the `filterChangeWatchedFiles` hook to avoid reporting changes inside of this `target` folder or the `.git` directory. It also takes care of updating the `rls.toml` while we're at it to avoid the need to subscribe to changes on package activation.

I also took some care to optimize these path comparison code paths by pre-computing the paths of interest and using a `for...in` loop rather than `Object.keys`.

/cc @damieng @daviwil because I think Rust is a super important target audience.