### PR TITLE
Rls command override

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
  - Go to definition (`ctrl` or `cmd` click)
  - Type information and Documentation on hover (hold `ctrl` or `cmd` for more information)
  - Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
+   ```toml
+   # rls.toml
+   features = ["serde"]
+   ```
 
 ## Install
 
@@ -19,6 +23,19 @@ $ apm install ide-rust
 ```
 
 Or you can install from Settings view by searching for `ide-rust`.
+
+
+## Overriding Rls
+The Rls command can be specified manually, for example to run from local source code:
+```cson
+# config.cson
+  ...
+  "ide-rust":
+    rlsCommandOverride: "rustup run nightly cargo run --manifest-path=/rls-src/Cargo.toml --release"
+```
+When set you'll be able to see, and remove, this from the package settings. After restarting atom an info message will inform you the override is in place.
+
+![](https://image.ibb.co/jsR65w/rls_Command_Override_Info.png)
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,14 +30,25 @@ function exec(command) {
   })
 }
 
+function clearIdeRustInfos() {
+  for (const note of atom.notifications.getNotifications()) {
+    if (note.getOptions()._src === 'ide-rust') {
+      note.dismiss()
+    }
+  }
+}
+
 function atomPrompt(message, options, buttons) {
+  clearIdeRustInfos()
+
   return new Promise((resolve, reject) => {
     const notification = atom.notifications.addInfo(
       message,
       Object.assign(
         {
           dismissable: true,
-          buttons: buttons.map(button => ({
+          _src: 'ide-rust',
+          buttons: (buttons || []).map(button => ({
             text: button,
             onDidClick: () => {
               resolve(button)
@@ -58,39 +69,48 @@ function installRustup() {
   return exec("curl https://sh.rustup.rs -sSf | sh -s -- -y")
 }
 
+function configToolchain() {
+  return atom.config.get('ide-rust.rlsToolchain')
+}
+
 // Installs nightly
-function installNightly() {
-  return exec("rustup toolchain install nightly")
+function installCompiler() {
+  return exec(`rustup toolchain install ${configToolchain()}`)
 }
 
 // Checks for rustup and nightly toolchain
 // If not found, asks to install. If user declines, throws error
 function checkToolchain() {
+
   return new Promise((resolve, reject) => {
-    exec("rustup toolchain list")
-      .then(results => {
-        const { stdout } = results
-        const matches = /^(?=nightly)(.*)$/im.exec(stdout)
-
-        // If found, we're done
-        if (matches) {
-          return resolve(matches[0])
-        }
-
+    exec(`rustup run ${configToolchain()} rustc --version`)
+      .then(resolve)
+      .catch(() => {
         // If not found, install it
         // Ask to install
         atomPrompt(
-          "`rustup` missing nightly toolchain",
+          `\`rustup\` missing ${configToolchain()} toolchain`,
           {
-            detail: "rustup toolchain install nightly"
+            detail: `rustup toolchain install ${configToolchain()}`
           },
           ["Install"]
         ).then(response => {
           if (response === "Install") {
-            installNightly()
+            atomPrompt(`Installing rust \`${configToolchain()}\`...`)
+            installCompiler()
               .then(checkToolchain)
               .then(resolve)
-              .catch(reject)
+              .catch(e => {
+                console.warn(e)
+                clearIdeRustInfos()
+                let err = (e + '').split('\n')
+                err = err.length && err[0] || `Error installing rust  \`${configToolchain()}\``
+                atom.notifications.addError(err, {
+                  detail: 'Check the toolchain is valid & connection is available',
+                  dismissable: true
+                })
+                resolve()
+              })
           } else {
             reject()
           }
@@ -119,11 +139,14 @@ function checkToolchain() {
         })
       })
   })
+  .then(() => clearIdeRustInfos())
 }
 
 // Check for and install RLS
 function checkRls() {
-  return exec("rustup component list --toolchain nightly").then(results => {
+  let toolchain = configToolchain()
+
+  return exec(`rustup component list --toolchain ${toolchain}`).then(results => {
     const { stdout } = results
     if (
       stdout.search(/^rls-preview.* \((default|installed)\)$/m) >= 0 &&
@@ -135,11 +158,25 @@ function checkRls() {
     }
 
     // Don't have RLS
-    return exec("rustup component add rls-preview --toolchain nightly")
-      .then(() => exec("rustup component add rust-src --toolchain nightly"))
+    return exec(`rustup component add rls-preview --toolchain ${toolchain}`)
+      .catch(e => {
+        atom.notifications.addError(`\`rls-preview\` was not found on \`${toolchain}\``, {
+          detail: 'Try configuring another toolchain, like a previous nightly or `beta`',
+          dismissable: true
+        })
+        e._logged = true
+        throw e
+      })
+      .then(() => exec(`rustup component add rust-src --toolchain ${toolchain}`))
       .then(() =>
-        exec("rustup component add rust-analysis --toolchain nightly")
+        exec(`rustup component add rust-analysis --toolchain ${toolchain}`)
       )
+      .catch(e => {
+        if (!e._logged)
+          atom.notifications.addError(`\`rust-src\`/\`rust-analysis\` not found on \`${toolchain}\``, {
+            dismissable: true
+          })
+      })
   })
 }
 
@@ -168,11 +205,26 @@ class RustLanguageClient extends AutoLanguageClient {
         }
       }
     }))
+
+    this.disposables.add(atom.config.onDidChange('ide-rust.rlsToolchain',
+      _.debounce(({ newValue }) => {
+        checkToolchain()
+          .then(() => checkRls())
+          .then(() => {
+            // TODO I'd actually like to restart all servers with the new toolchain here
+            // but this doesn't currently seem possible see https://github.com/atom/atom-languageclient/issues/135
+            atomPrompt(`Switched Rls toolchain to \`${newValue}\``, {
+              detail: 'Close and reopen editor windows or restart ' +
+                'atom to ensure usage of the new toolchain'
+            })
+          })
+      }, 1000)
+    ))
   }
 
   deactivate() {
-    super.deactivate()
     this.disposables.dispose()
+    return super.deactivate()
   }
 
   postInitialization(server) {
@@ -221,7 +273,7 @@ class RustLanguageClient extends AutoLanguageClient {
           )
         }
 
-        return cp.spawn("rustup", ["run", "nightly", "rls"], {
+        return cp.spawn("rustup", ["run", configToolchain(), "rls"], {
           env: {
             PATH: getPath(),
             RUST_SRC_PATH: rustSrcPath
@@ -231,4 +283,14 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 }
 
-module.exports = new RustLanguageClient()
+const client = new RustLanguageClient()
+
+client.config = {
+  rlsToolchain: {
+    description: 'Sets the toolchain installed using rustup and used to run the Rls. For example ***beta*** or ***nightly-2017-11-01***.',
+    type: 'string',
+    default: 'nightly'
+  }
+}
+
+module.exports = client

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,11 @@ function configToolchain() {
   return atom.config.get('ide-rust.rlsToolchain')
 }
 
+/** Developer override of the command to start a Rls instance */
+function rlsCommandOverride() {
+  return atom.config.get('ide-rust.rlsCommandOverride')
+}
+
 // Installs nightly
 function installCompiler() {
   return exec(`rustup toolchain install ${configToolchain()}`)
@@ -273,12 +278,26 @@ class RustLanguageClient extends AutoLanguageClient {
           )
         }
 
-        return cp.spawn("rustup", ["run", configToolchain(), "rls"], {
-          env: {
-            PATH: getPath(),
-            RUST_SRC_PATH: rustSrcPath
+        let cmdOverride = rlsCommandOverride()
+        let env = {
+          PATH: getPath(),
+          RUST_SRC_PATH: rustSrcPath
+        }
+
+        if (cmdOverride) {
+          if (!this._warnedAboutRlsCommandOverride) {
+            clearIdeRustInfos()
+            atom.notifications.addInfo(`Using rls command \`${cmdOverride}\``)
+            this._warnedAboutRlsCommandOverride = true
           }
-        })
+          return cp.spawn(cmdOverride, {
+            env,
+            shell: true
+          })
+        }
+        else {
+          return cp.spawn("rustup", ["run", configToolchain(), "rls"], { env })
+        }
       })
   }
 }


### PR DESCRIPTION
This PR allows overriding the Rls exec command. This is really useful if you're troubleshooting or developing the Rls. For example I'm using it to test my local Rls changes.

Initially it has to be added to config.cson manually, this is because this option _shouldn't_ be of interest to most users. Note: Once you have added something to config.cson you'll be able to edit/remove it from the ide-rust settings menu.

Built on top of / includes #20.

## Overriding Rls
The Rls command can be specified manually, for example to run from local source code:
```cson
# config.cson
  ...
  "ide-rust":
    rlsCommandOverride: "rustup run nightly cargo run --manifest-path=/rls-src/Cargo.toml --release"
```
When set you'll be able to see, and remove, this from the package settings. After restarting atom an info message will inform you the override is in place.

![](https://image.ibb.co/jsR65w/rls_Command_Override_Info.png)