### PR TITLE
Normalize the package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-rust",
   "main": "./lib/index",
   "version": "0.6.0",
-  "description": "Rust IDE support for Atom, powered by the Rust Langauge Server (RLS)",
+  "description": "Rust language support for Atom-IDE",
   "repository": "https://github.com/mehcode/atom-ide-rust",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
With respect to other Atom IDE packages such as [ide-java](https://github.com/atom/ide-java/blob/master/package.json#L5) or [ide-php](https://github.com/atom/ide-php/blob/master/package.json#L5). The fact that this plugin uses the RLS in the backend is an implementation detail.