### PR TITLE
Add busySignal support + window:reload button on toolchain change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const os = require("os")
 const path = require("path")
 const _ = require('underscore-plus')
 const RlsProject = require('./rls-project.js')
-const { CompositeDisposable } = require('atom')
+const { CompositeDisposable, Disposable } = require('atom')
 const { AutoLanguageClient } = require("atom-languageclient")
 
 function getPath() {
@@ -80,9 +80,12 @@ function installCompiler() {
   return exec(`rustup toolchain install ${configToolchain()}`)
 }
 
-// Checks for rustup and nightly toolchain
-// If not found, asks to install. If user declines, throws error
-function checkToolchain() {
+/**
+ * Checks for rustup and nightly toolchain
+ * If not found, asks to install. If user declines, throws error
+ * @param [busySignalService]
+ */
+function checkToolchain(busySignalService) {
 
   return new Promise((resolve, reject) => {
     exec(`rustup run ${configToolchain()} rustc --version`)
@@ -98,8 +101,7 @@ function checkToolchain() {
           ["Install"]
         ).then(response => {
           if (response === "Install") {
-            atomPrompt(`Installing rust \`${configToolchain()}\`...`)
-            installCompiler()
+            let installPromise = installCompiler()
               .then(checkToolchain)
               .then(resolve)
               .catch(e => {
@@ -113,6 +115,10 @@ function checkToolchain() {
                 })
                 resolve()
               })
+
+              busySignalService && busySignalService.reportBusyWhile(
+                `Installing rust \`${configToolchain()}\``,
+                () => installPromise)
           } else {
             reject()
           }
@@ -144,8 +150,11 @@ function checkToolchain() {
   .then(() => clearIdeRustInfos())
 }
 
-// Check for and install RLS
-function checkRls() {
+/**
+ * Check for and install Rls
+ * @param [busySignalService]
+ */
+function checkRls(busySignalService) {
   let toolchain = configToolchain()
 
   return exec(`rustup component list --toolchain ${toolchain}`).then(results => {
@@ -160,7 +169,7 @@ function checkRls() {
     }
 
     // Don't have RLS
-    return exec(`rustup component add rls-preview --toolchain ${toolchain}`)
+    let installRlsPromise = exec(`rustup component add rls-preview --toolchain ${toolchain}`)
       .catch(e => {
         atom.notifications.addError(`\`rls-preview\` was not found on \`${toolchain}\``, {
           detail: 'Try configuring another toolchain, like a previous nightly or `beta`',
@@ -179,6 +188,12 @@ function checkRls() {
             dismissable: true
           })
       })
+
+    busySignalService && busySignalService.reportBusyWhile(
+      `Adding components rls-preview, rust-src, rust-analysis`,
+      () => installRlsPromise)
+
+    return installRlsPromise
   })
 }
 
@@ -188,6 +203,21 @@ class RustLanguageClient extends AutoLanguageClient {
     /** (projectPath -> RlsProject) mappings */
     this.projects = {}
     this.disposables = new CompositeDisposable()
+
+    /** Configuration schema */
+    this.config = {
+      rlsToolchain: {
+        description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
+          ' For example ***beta*** or ***nightly-2017-11-01***.',
+        type: 'string',
+        default: 'nightly'
+      }
+    }
+
+    this.consumeBusySignal = (busySignalService) => {
+      this._busySignalService = busySignalService
+      return new Disposable(() => delete this._busySignalService)
+    }
   }
 
   activate() {
@@ -210,14 +240,19 @@ class RustLanguageClient extends AutoLanguageClient {
 
     this.disposables.add(atom.config.onDidChange('ide-rust.rlsToolchain',
       _.debounce(({ newValue }) => {
-        checkToolchain()
-          .then(() => checkRls())
+        checkToolchain(this._busySignalService)
+          .then(() => checkRls(this._busySignalService))
           .then(() => {
             // TODO I'd actually like to restart all servers with the new toolchain here
             // but this doesn't currently seem possible see https://github.com/atom/atom-languageclient/issues/135
+            // Until it is possible the 'Reload' button should help
             atomPrompt(`Switched Rls toolchain to \`${newValue}\``, {
-              detail: 'Close and reopen editor windows or restart ' +
-                'atom to ensure usage of the new toolchain'
+              detail: 'Close and reopen editor windows or reload ' +
+                'atom to ensure usage of the new toolchain',
+              buttons: [{
+                text: 'Reload',
+                onDidClick: () => atom.commands.dispatch(window, 'window:reload')
+              }]
             })
           })
       }, 1000)
@@ -260,11 +295,11 @@ class RustLanguageClient extends AutoLanguageClient {
 
   startServerProcess() {
     let toolchain
-    return checkToolchain()
+    return checkToolchain(this._busySignalService)
       .then(toolchain_ => {
         toolchain = toolchain_
 
-        return checkRls()
+        return checkRls(this._busySignalService)
       })
       .then(() => {
         let rustSrcPath = process.env["RUST_SRC_PATH"] || ""
@@ -299,14 +334,4 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 }
 
-const client = new RustLanguageClient()
-
-client.config = {
-  rlsToolchain: {
-    description: 'Sets the toolchain installed using rustup and used to run the Rls. For example ***beta*** or ***nightly-2017-11-01***.',
-    type: 'string',
-    default: 'nightly'
-  }
-}
-
-module.exports = client
+module.exports = new RustLanguageClient()

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,11 +213,12 @@ class RustLanguageClient extends AutoLanguageClient {
         default: 'nightly'
       }
     }
+  }
 
-    this.consumeBusySignal = (busySignalService) => {
-      this._busySignalService = busySignalService
-      return new Disposable(() => delete this._busySignalService)
-    }
+  /** Injects busySignalService, called by atom services */
+  consumeBusySignal(busySignalService) {
+    this._busySignalService = busySignalService
+    return new Disposable(() => delete this._busySignalService)
   }
 
   activate() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ide-rust",
-  "version": "0.4.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "versions": {
         "0.1.0": "consumeDatatip"
       }
+    },
+    "atom-ide-busy-signal": {
+      "versions": {
+        "0.1.0": "consumeBusySignal"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
This change adds _atom-ide-busy-signal_ service support.

* Replaces `Installing rust...` notification with busy signal
* Adds busy signal for `Adding components rls-preview, rust-src, rust-analysis` (previously not notified)
* Also adds a **Reload** button to `Switched Rls toolchain to...` notification _(will do the same as ctrl-shift-F5)_

![busysignal-reloadbutton](https://user-images.githubusercontent.com/2331607/33174045-3da2cc5a-d04e-11e7-86be-2eda1bfb228d.gif)
