### PR TITLE
Propogate error when rls is not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -150,6 +150,24 @@ function checkToolchain(busySignalService) {
   .then(() => clearIdeRustInfos())
 }
 
+/** @param {string} [toolchain]  */
+function serverEnv(toolchain) {
+  const env = { PATH: getPath() }
+
+  if (toolchain) {
+    let rustSrcPath = process.env["RUST_SRC_PATH"] || ""
+    if (rustSrcPath.length === 0) {
+      rustSrcPath = path.join(
+        os.homedir(),
+        ".rustup/toolchains/" + toolchain + "/lib/rustlib/src/rust/src/"
+      )
+    }
+    env.RUST_SRC_PATH = rustSrcPath
+  }
+
+  return env
+}
+
 /**
  * Check for and install Rls
  * @param [busySignalService]
@@ -183,10 +201,12 @@ function checkRls(busySignalService) {
         exec(`rustup component add rust-analysis --toolchain ${toolchain}`)
       )
       .catch(e => {
-        if (!e._logged)
+        if (!e._logged) {
           atom.notifications.addError(`\`rust-src\`/\`rust-analysis\` not found on \`${toolchain}\``, {
             dismissable: true
           })
+        }
+        throw e
       })
 
     busySignalService && busySignalService.reportBusyWhile(
@@ -289,42 +309,23 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 
   startServerProcess() {
-    let toolchain
-    return checkToolchain(this.busySignalService)
-      .then(toolchain_ => {
-        toolchain = toolchain_
-
-        return checkRls(this.busySignalService)
+    let cmdOverride = rlsCommandOverride()
+    if (cmdOverride) {
+      if (!this._warnedAboutRlsCommandOverride) {
+        clearIdeRustInfos()
+        atom.notifications.addInfo(`Using rls command \`${cmdOverride}\``)
+        this._warnedAboutRlsCommandOverride = true
+      }
+      return cp.spawn(cmdOverride, {
+        env: serverEnv(),
+        shell: true
       })
-      .then(() => {
-        let rustSrcPath = process.env["RUST_SRC_PATH"] || ""
-        if (rustSrcPath.length === 0) {
-          rustSrcPath = path.join(
-            os.homedir(),
-            ".rustup/toolchains/" + toolchain + "/lib/rustlib/src/rust/src/"
-          )
-        }
+    }
 
-        let cmdOverride = rlsCommandOverride()
-        let env = {
-          PATH: getPath(),
-          RUST_SRC_PATH: rustSrcPath
-        }
-
-        if (cmdOverride) {
-          if (!this._warnedAboutRlsCommandOverride) {
-            clearIdeRustInfos()
-            atom.notifications.addInfo(`Using rls command \`${cmdOverride}\``)
-            this._warnedAboutRlsCommandOverride = true
-          }
-          return cp.spawn(cmdOverride, {
-            env,
-            shell: true
-          })
-        }
-        else {
-          return cp.spawn("rustup", ["run", configToolchain(), "rls"], { env })
-        }
+    return checkToolchain(this.busySignalService)
+      .then(toolchain => checkRls(this.busySignalService).then(() => toolchain))
+      .then(toolchain => {
+        cp.spawn("rustup", ["run", configToolchain(), "rls"], { env: serverEnv(toolchain) })
       })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ide-rust",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
* Propogate error when rls is not found
* Don't check toolchain/rls when `rlsCommandOverride` is present.

Currently server startup can return a non failing promise when Rls is missing, despite showing the correct error notification. This can cause atom-languageclient to show busy-signal 'initializing' without end, which is how I noticed it.

I also removed the toolchain/rls check when using `rlsCommandOverride` and simplified this branch of the code.