### PR TITLE
Add filter watch ignores for target/debug & target/release

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -327,7 +327,10 @@ class RustLanguageClient extends AutoLanguageClient {
     // TODO ignore all files and wait for `client/registerCapability`
     // to inform us of the correct files to watch, until that's implemented
     // these filters take eliminate the brunt of the watch message spam
-    return !filePath.includes('/.git/') && !filePath.includes('/target/rls/')
+    return !filePath.includes('/.git/') &&
+      !filePath.includes('/target/rls/') &&
+      !filePath.includes('/target/debug/') &&
+      !filePath.includes('/target/release/')
   }
 
   startServerProcess() {


### PR DESCRIPTION
Prevents masses of watched file change messages when building debug/release while Rls is running.
These aren't a huge problem as Rls ignores them, but still worth making a small addition to ignore them as they still spam the logs.