### PR TITLE
Add toolchain update checking on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,24 @@ Rust language support for Atom-IDE, powered by the Rust Language Server (RLS).
  - Go to definition (`ctrl` or `cmd` click)
  - Type information and Documentation on hover (hold `ctrl` or `cmd` for more information)
  - Rls toolchain selection in package settings
+ - Rls toolchain update checking at startup
  - Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
    ```toml
    # rls.toml
    features = ["serde"]
    ```
 
+## Prerequisites
+[rustup](https://www.rustup.rs) is required; used to install and manage the Rls toolchains.
+
 ## Install
-
 You can install from the command line with:
-
 ```
 $ apm install ide-rust
 ```
-
 Or you can install from Settings view by searching for `ide-rust`.
 
+No other packages or manual setup is required as these will be handled with user prompts after install.
 
 ## Overriding Rls
 The Rls command can be specified manually, for example to run from local source code:
@@ -47,5 +49,4 @@ If stuff isn't working you can try **enabling logging** to debug:
 This will spit out language server message logging into the atom console. Check if requests/responses are being sent or are incorrect. It will also include any Rls stderr messages (as warnings) which may point to Rls bugs.
 
 ## License
-
 MIT License. See the [license](LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Rust language support for Atom-IDE, powered by the Rust Language Server (RLS).
    features = ["serde"]
    ```
 
-## Prerequisites
-[rustup](https://www.rustup.rs) is required; used to install and manage the Rls toolchains.
-
 ## Install
 You can install from the command line with:
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ function atomPrompt(message, options, buttons) {
   })
 }
 
-/** @return {Promise<boolean>} toolchain update is available */
+/** @return {Promise<string>} new version of update available (falsy otherwise) */
 function checkForToolchainUpdates() {
   const toolchain = configToolchain()
 
@@ -82,7 +82,8 @@ function checkForToolchainUpdates() {
           let rustcInfo = body.match(/(\[pkg\.rustc\][^\[]*)/m)
           if (!rustcInfo) return reject(new Error('could not split channel toml output'))
           let rustcVersion = toml.parse(rustcInfo[1]).pkg.rustc.version.trim()
-          resolve(!stdout.trim().endsWith(rustcVersion) && body.includes('rls-preview'))
+          resolve(!stdout.trim().endsWith(rustcVersion) && body.includes('rls-preview') &&
+            `rustc ${rustcVersion}`)
         })
       })
     })
@@ -316,9 +317,10 @@ class RustLanguageClient extends AutoLanguageClient {
 
     if (atom.config.get('ide-rust.checkForToolchainUpdates') && !datedRegex.test(toolchain)) {
       checkForToolchainUpdates()
-        .then(available => {
-          if (available) {
+        .then(newVersion => {
+          if (newVersion) {
             atom.notifications.addInfo(`Rls \`${toolchain}\` toolchain update available`, {
+              description: newVersion,
               _src: 'ide-rust',
               dismissable: true,
               buttons: [{

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const cp = require("child_process")
 const os = require("os")
 const path = require("path")
+const toml = require('toml')
 const _ = require('underscore-plus')
 const RlsProject = require('./rls-project.js')
 const { CompositeDisposable, Disposable } = require('atom')
@@ -58,6 +59,33 @@ function atomPrompt(message, options, buttons) {
     )
 
     notification.onDidDismiss(() => resolve(null))
+  })
+}
+
+/** @return {Promise<boolean>} toolchain update is available */
+function checkForToolchainUpdates() {
+  const toolchain = configToolchain()
+
+  return exec(`rustup run ${toolchain} rustc --version`).then(({ stdout }) => {
+    return new Promise((resolve, reject) => {
+      require("https").get(`https://static.rust-lang.org/dist/channel-rust-${toolchain}.toml`,
+        res => {
+        if (res.statusCode !== 200) {
+          return reject(new Error(`check for toolchain update failed, status: ${res.statusCode}`))
+        }
+
+        res.setEncoding("utf8")
+        let body = ""
+        res.on("data", data => body += data)
+        res.on("end", () => {
+          // use a subsection as toml is slow to parse fully
+          let rustcInfo = body.match(/(\[pkg\.rustc\][^\[]*)/m)
+          if (!rustcInfo) return reject(new Error('could not split channel toml output'))
+          let rustcVersion = toml.parse(rustcInfo[1]).pkg.rustc.version.trim()
+          resolve(!stdout.trim().endsWith(rustcVersion) && body.includes('rls-preview'))
+        })
+      })
+    })
   })
 }
 
@@ -253,8 +281,30 @@ class RustLanguageClient extends AutoLanguageClient {
           ' For example ***beta*** or ***nightly-2017-11-01***.',
         type: 'string',
         default: 'nightly'
+      },
+      checkForToolchainUpdates: {
+        description: 'Check on startup for toolchain updates, prompting to install if available',
+        type: 'boolean',
+        default: true
       }
     }
+  }
+
+  /**
+   * @param {string} reason Reason for the restart, shown in the prompt
+   * TODO I'd actually like to restart all servers with the new toolchain here
+   * but this doesn't currently seem possible see https://github.com/atom/atom-languageclient/issues/135
+   * Until it is possible a 'Reload' prompt is helpful
+   */
+  _restartLanguageServers(reason) {
+    atomPrompt(reason, {
+      detail: 'Close and reopen editor windows or reload atom to ensure usage of the new toolchain',
+      buttons: [{
+        text: 'Reload',
+        className: 'btn-warning',
+        onDidClick: () => atom.commands.dispatch(window, 'window:reload')
+      }]
+    })
   }
 
   activate() {
@@ -279,21 +329,37 @@ class RustLanguageClient extends AutoLanguageClient {
       _.debounce(({ newValue }) => {
         checkToolchain(this.busySignalService)
           .then(() => checkRls(this.busySignalService))
-          .then(() => {
-            // TODO I'd actually like to restart all servers with the new toolchain here
-            // but this doesn't currently seem possible see https://github.com/atom/atom-languageclient/issues/135
-            // Until it is possible the 'Reload' button should help
-            atomPrompt(`Switched Rls toolchain to \`${newValue}\``, {
-              detail: 'Close and reopen editor windows or reload ' +
-                'atom to ensure usage of the new toolchain',
-              buttons: [{
-                text: 'Reload',
-                onDidClick: () => atom.commands.dispatch(window, 'window:reload')
-              }]
-            })
-          })
+          .then(() => this._restartLanguageServers(`Switched Rls toolchain to \`${newValue}\``))
       }, 1000)
     ))
+
+    // check for toolchain updates if installed & not dated
+    const toolchain = configToolchain()
+    const datedRegex = /-\d{4,}-\d{2}-\d{2}$/
+    if (atom.config.get('ide-rust.checkForToolchainUpdates') && !datedRegex.test(toolchain)) {
+      checkForToolchainUpdates()
+        .then(available => {
+          if (available) {
+            atomPrompt(`Rls \`${toolchain}\` toolchain update available`, {
+              buttons: [{
+                text: 'Update',
+                className: 'btn-success',
+                onDidClick: () => {
+                  let updatePromise = exec(`rustup update ${toolchain}`)
+                    .then(() => checkToolchain())
+                    .then(() => checkRls())
+                    .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
+                    .catch(e => console.error(e))
+                  this.busySignalService && this.busySignalService.reportBusyWhile(
+                    `Updating rust \`${toolchain}\` toolchain`,
+                    () => updatePromise)
+                }
+              }]
+            })
+          }
+        })
+        .catch(e => console.error(e))
+    }
   }
 
   deactivate() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,7 +297,9 @@ class RustLanguageClient extends AutoLanguageClient {
    * Until it is possible a 'Reload' prompt is helpful
    */
   _restartLanguageServers(reason) {
-    atomPrompt(reason, {
+    atom.notifications.addSuccess(reason, {
+      _src: 'ide-rust',
+      dismissable: true,
       detail: 'Close and reopen editor windows or reload atom to ensure usage of the new toolchain',
       buttons: [{
         text: 'Reload',
@@ -305,6 +307,40 @@ class RustLanguageClient extends AutoLanguageClient {
         onDidClick: () => atom.commands.dispatch(window, 'window:reload')
       }]
     })
+  }
+
+  // check for toolchain updates if installed & not dated
+  _promptToUpdateToolchain() {
+    const toolchain = configToolchain()
+    const datedRegex = /-\d{4,}-\d{2}-\d{2}$/
+
+    if (atom.config.get('ide-rust.checkForToolchainUpdates') && !datedRegex.test(toolchain)) {
+      checkForToolchainUpdates()
+        .then(available => {
+          if (available) {
+            atom.notifications.addInfo(`Rls \`${toolchain}\` toolchain update available`, {
+              _src: 'ide-rust',
+              dismissable: true,
+              buttons: [{
+                text: 'Update',
+                onDidClick: () => {
+                  clearIdeRustInfos()
+
+                  let updatePromise = exec(`rustup update ${toolchain}`)
+                    .then(() => checkToolchain())
+                    .then(() => checkRls())
+                    .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
+                    .catch(e => console.error(e))
+                  this.busySignalService && this.busySignalService.reportBusyWhile(
+                    `Updating rust \`${toolchain}\` toolchain`,
+                    () => updatePromise)
+                }
+              }]
+            })
+          }
+        })
+        .catch(e => console.error(e))
+    }
   }
 
   activate() {
@@ -330,36 +366,11 @@ class RustLanguageClient extends AutoLanguageClient {
         checkToolchain(this.busySignalService)
           .then(() => checkRls(this.busySignalService))
           .then(() => this._restartLanguageServers(`Switched Rls toolchain to \`${newValue}\``))
+          .then(() => this._promptToUpdateToolchain())
       }, 1000)
     ))
 
-    // check for toolchain updates if installed & not dated
-    const toolchain = configToolchain()
-    const datedRegex = /-\d{4,}-\d{2}-\d{2}$/
-    if (atom.config.get('ide-rust.checkForToolchainUpdates') && !datedRegex.test(toolchain)) {
-      checkForToolchainUpdates()
-        .then(available => {
-          if (available) {
-            atomPrompt(`Rls \`${toolchain}\` toolchain update available`, {
-              buttons: [{
-                text: 'Update',
-                className: 'btn-success',
-                onDidClick: () => {
-                  let updatePromise = exec(`rustup update ${toolchain}`)
-                    .then(() => checkToolchain())
-                    .then(() => checkRls())
-                    .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
-                    .catch(e => console.error(e))
-                  this.busySignalService && this.busySignalService.reportBusyWhile(
-                    `Updating rust \`${toolchain}\` toolchain`,
-                    () => updatePromise)
-                }
-              }]
-            })
-          }
-        })
-        .catch(e => console.error(e))
-    }
+    this._promptToUpdateToolchain()
   }
 
   deactivate() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,23 @@
 {
   "name": "ide-rust",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "atom-languageclient": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.7.2.tgz",
-      "integrity": "sha1-mVnFhFacSNe+IqmV3hoStfAsnfY=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.7.3.tgz",
+      "integrity": "sha1-TVyFm6qz8zlNxFEpk1swN3GVQvs=",
       "requires": {
         "vscode-jsonrpc": "3.5.0"
       }
     },
     "atom-package-deps": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.0.tgz",
-      "integrity": "sha1-u4PwqXZWO0i+TquJ58hjHD7shI0=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.1.tgz",
+      "integrity": "sha512-zphrAt856e750W7ZwK2M96buUG0ryLrIclogbliATSCUsmhvvcdq4TidgC3bWN0eEo6unRbR5gYVsJl6WRvs5g==",
       "requires": {
         "atom-package-path": "1.1.0",
-        "sb-exec": "3.1.0",
         "sb-fs": "3.0.0",
         "semver": "5.4.1"
       }
@@ -31,38 +30,15 @@
         "sb-callsite": "1.1.2"
       }
     },
-    "consistent-env": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
-      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
-      "requires": {
-        "lodash.uniq": "4.5.0"
-      }
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
     "sb-callsite": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sb-callsite/-/sb-callsite-1.1.2.tgz",
       "integrity": "sha1-KBkftm1k46PukghKlakPy1ECJDs="
-    },
-    "sb-exec": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-3.1.0.tgz",
-      "integrity": "sha1-NMxlCIoRZ1Lrcg/d7/ZtLC6V7FE=",
-      "requires": {
-        "consistent-env": "1.3.1",
-        "lodash.uniq": "4.5.0",
-        "sb-npm-path": "2.0.0"
-      }
     },
     "sb-fs": {
       "version": "3.0.0",
@@ -71,20 +47,6 @@
       "requires": {
         "sb-promisify": "2.0.2",
         "strip-bom-buf": "1.0.0"
-      }
-    },
-    "sb-memoize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
-      "integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
-    },
-    "sb-npm-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
-      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
-      "requires": {
-        "sb-memoize": "1.0.2",
-        "sb-promisify": "2.0.2"
       }
     },
     "sb-promisify": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.7.2",
-    "atom-package-deps": "^4.6.0",
+    "atom-languageclient": "^0.7.3",
+    "atom-package-deps": "^4.6.1",
     "toml": "^2.3.3",
     "underscore-plus": "^1.6.6"
   },


### PR DESCRIPTION
This pr adds a check for available updates to the selected rust/rls toolchain on startup.

When available a prompt will allow updating
![screenshot from 2018-01-11 10-41-13](https://user-images.githubusercontent.com/2331607/34821585-2b4fbed4-f6bc-11e7-8514-1a721e9a396e.png)

* Toolchain updating
  * Check for toolchain update at startup
  * Check for toolchain update after switching toolchain
  * Only prompts to update if update has _'rls-preview'_
  * Skips check if toolchain is dated _(e.g. nightly-2017-12-12)_
  * Enabled/disable in settings _(default enabled)_
* Chang _'switched toolchain'_ prompt to a _success_ style one
* Add toolchain update info to readme features
* Add 'other packages not required' note to readme _Install_ section

Resolves #30 