### PR TITLE
Automatically restart language servers on toolchain change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,23 +273,9 @@ class RustLanguageClient extends AutoLanguageClient {
     }
   }
 
-  /**
-   * @param {string} reason Reason for the restart, shown in the prompt
-   * TODO I'd actually like to restart all servers with the new toolchain here
-   * but this doesn't currently seem possible see https://github.com/atom/atom-languageclient/issues/135
-   * Until it is possible a 'Reload' prompt is helpful
-   */
+  /** @param {string} reason Reason for the restart shown in the notification */
   _restartLanguageServers(reason) {
-    atom.notifications.addSuccess(reason, {
-      _src: 'ide-rust',
-      dismissable: true,
-      detail: 'Close and reopen editor windows or reload atom to ensure usage of the new toolchain',
-      buttons: [{
-        text: 'Reload',
-        className: 'btn-warning',
-        onDidClick: () => atom.commands.dispatch(window, 'window:reload')
-      }]
-    })
+    this.restartAllServers().then(() => atom.notifications.addSuccess(reason, { _src: 'ide-rust' }))
   }
 
   // check for toolchain updates if installed & not dated

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "atom-languageclient": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.8.0.tgz",
-      "integrity": "sha1-URUfBOUpnYMB1KZU36ZW8eKCGJA=",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.8.1.tgz",
+      "integrity": "sha1-UCzOt36vKB4g3aDwdSDCN5+Zrqk=",
       "requires": {
         "fuzzaldrin-plus": "0.6.0",
         "vscode-jsonrpc": "3.5.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.8.0",
+    "atom-languageclient": "^0.8.1",
     "atom-package-deps": "^4.6.1",
     "toml": "^2.3.3",
     "underscore-plus": "^1.6.6"


### PR DESCRIPTION
Update to atom-languageclient 0.8.1 allows programmatic server restart, so we can simply notify users after switching toolchain instead of having to reload atom. 

https://github.com/atom/atom-languageclient/pull/171 fixes #39