### PR TITLE
Toolchain handling II

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,8 +6,13 @@ module.exports = {
     browser: true,
   },
   rules: {
-    semi: ["error", "never"],
+    semi: ["warn", "never"],
     "no-console": "off",
+    "valid-jsdoc": ["warn", {
+      requireParamDescription: false,
+      requireReturn: false,
+      requireReturnDescription: false,
+    }],
   },
   globals: {
     atom: true,

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Rust language support for Atom-IDE, powered by the Rust Language Server (RLS).
    # rls.toml
    features = ["serde"]
    ```
+ - Graceful handling of Rls being missing from the distribution _(which is somewhat common on the nightly channel)_
+   * Warns before installing a rust version without Rls or when using an already installed one
+   * Automatic detection of, and prompt to install, the latest working dated release
 
 ## Install
 You can install from the command line with:

--- a/lib/dist-fetch.js
+++ b/lib/dist-fetch.js
@@ -1,0 +1,109 @@
+const https = require('https')
+const _ = require('underscore-plus')
+
+const datedNightlyHasRlsCache = new Map()
+const DATED_REGEX = /(^[^-]+)-(\d{4,}-\d{2}-\d{2})$/
+
+/**
+ * @param {Date|string} date
+ * @param {string=} channel
+ * @return {Promise<string>} toolchain name
+ */
+function checkDatedNightlyHasRls(date, channel='nightly') {
+  const dateString = _.isString(date) ? date : date.toISOString().split('T')[0]
+  const cacheKey = `${channel}-${dateString}`
+
+  let fetch = datedNightlyHasRlsCache.get(cacheKey) || new Promise((resolve, reject) => {
+    https.get(`https://static.rust-lang.org/dist/${dateString}/channel-rust-${channel}.toml`, res => {
+        if (res.statusCode !== 200) {
+          return reject(new Error(`Failed, status: ${res.statusCode}`))
+        }
+        res.setEncoding("utf8")
+        let body = ""
+        res.on("data", data => {
+          body += data
+          if (body.includes('rls-preview')) resolve(cacheKey)
+        })
+        res.on("end", () => reject(new Error("no 'rls-preview'")))
+      })
+      .on("error", e => {
+        datedNightlyHasRlsCache.delete(cacheKey)
+        reject(e)
+      })
+  })
+
+  if (!datedNightlyHasRlsCache.has(cacheKey)) {
+    datedNightlyHasRlsCache.set(cacheKey, fetch)
+  }
+
+  return fetch
+}
+
+/** @return {Promise<string>} latest nightly dated version with rls-preview */
+function fetchLatestDatedNightlyWithRls() {
+  const aDayMillis = 24 * 60 * 60 * 1000
+  const minDate = new Date(Date.now() - 30 * aDayMillis)
+
+  const check = day => {
+    return checkDatedNightlyHasRls(day)
+      .catch(e => {
+        if (e && e.code === 'ENOTFOUND') throw e
+
+        const yesterday = new Date(day - aDayMillis)
+        if (yesterday >= minDate) return check(yesterday)
+        else throw new Error("No nightly with 'rls-preview'")
+      })
+  }
+
+  return check(new Date())
+}
+
+/**
+ * @param {string} arg.toolchain toolchain to check
+ * @param {string} [arg.currentVersion] current installed rustc version
+ * @return {Promise<?string>} new version of update available (falsy otherwise)
+ */
+function fetchLatestDist({ toolchain, currentVersion="none" }) {
+  return new Promise((resolve, reject) => {
+    https.get(`https://static.rust-lang.org/dist/channel-rust-${toolchain}.toml`, res => {
+      if (res.statusCode !== 200) {
+        return reject(new Error(`check for toolchain update failed, status: ${res.statusCode}`))
+      }
+
+      res.setEncoding("utf8")
+      let body = ""
+      res.on("data", data => body += data)
+      res.on("end", () => {
+        // use a subsection as toml is slow to parse fully
+        let rustcInfo = body.match(/(\[pkg\.rustc\][^[]*)/m)
+        if (!rustcInfo) return reject(new Error('could not split channel toml output'))
+        let rustcVersion = require('toml').parse(rustcInfo[1]).pkg.rustc.version.trim()
+        resolve(
+          !currentVersion.trim().endsWith(rustcVersion) &&
+          body.includes('rls-preview') &&
+          `rustc ${rustcVersion}`
+        )
+      })
+    })
+  })
+}
+
+/**
+ * Check a toolchain has rls, this can be done before installing
+ * @param {string} toolchain
+ * @return {Promise<boolean>}
+ */
+function checkHasRls(toolchain) {
+  let dated = toolchain.match(DATED_REGEX)
+  if (dated) {
+    return checkDatedNightlyHasRls(dated[2], dated[1]).then(() => true).catch(() => false)
+  }
+  return fetchLatestDist({ toolchain }).then(v => !!v).catch(() => false)
+}
+
+module.exports = {
+  fetchLatestDatedNightlyWithRls,
+  fetchLatestDist,
+  checkHasRls,
+  DATED_REGEX,
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,9 @@ function atomPrompt(message, options, buttons) {
 function checkForToolchainUpdates() {
   const toolchain = configToolchain()
 
-  return exec(`rustup run ${toolchain} rustc --version`).then(({ stdout }) => {
+  return exec(`rustup run ${toolchain} rustc --version`).then(({
+    stdout
+  }) => {
     return new Promise((resolve, reject) => {
       require("https")
         .get(`https://static.rust-lang.org/dist/channel-rust-${toolchain}.toml`, res => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,16 @@
 const cp = require("child_process")
 const os = require("os")
 const path = require("path")
-const toml = require('toml')
 const _ = require('underscore-plus')
-const RlsProject = require('./rls-project.js')
 const { CompositeDisposable } = require('atom')
 const { AutoLanguageClient } = require("atom-languageclient")
+const RlsProject = require('./rls-project.js')
+const {
+  fetchLatestDatedNightlyWithRls,
+  fetchLatestDist,
+  checkHasRls,
+  DATED_REGEX,
+} = require('./dist-fetch')
 
 function getPath() {
   // Make sure the cargo directory is in PATH
@@ -62,34 +67,6 @@ function atomPrompt(message, options, buttons) {
   })
 }
 
-/** @return {Promise<string>} new version of update available (falsy otherwise) */
-function checkForToolchainUpdates() {
-  const toolchain = configToolchain()
-
-  return exec(`rustup run ${toolchain} rustc --version`).then(({ stdout }) => {
-    return new Promise((resolve, reject) => {
-      require("https")
-        .get(`https://static.rust-lang.org/dist/channel-rust-${toolchain}.toml`, res => {
-          if (res.statusCode !== 200) {
-            return reject(new Error(`check for toolchain update failed, status: ${res.statusCode}`))
-          }
-
-          res.setEncoding("utf8")
-          let body = ""
-          res.on("data", data => body += data)
-          res.on("end", () => {
-            // use a subsection as toml is slow to parse fully
-            let rustcInfo = body.match(/(\[pkg\.rustc\][^[]*)/m)
-            if (!rustcInfo) return reject(new Error('could not split channel toml output'))
-            let rustcVersion = toml.parse(rustcInfo[1]).pkg.rustc.version.trim()
-            resolve(!stdout.trim().endsWith(rustcVersion) && body.includes('rls-preview') &&
-              `rustc ${rustcVersion}`)
-          })
-        })
-    })
-  })
-}
-
 // Installs rustup
 function installRustup() {
   return exec("curl https://sh.rustup.rs -sSf | sh -s -- -y")
@@ -99,7 +76,7 @@ function configToolchain() {
   return atom.config.get('ide-rust.rlsToolchain')
 }
 
-/** Developer override of the command to start a Rls instance */
+/** @return {?string} developer override of the command to start a Rls instance */
 function rlsCommandOverride() {
   return atom.config.get('ide-rust.rlsCommandOverride')
 }
@@ -112,52 +89,81 @@ function installCompiler() {
 /**
  * Checks for rustup and nightly toolchain
  * If not found, asks to install. If user declines, throws error
- * @param [busySignalService]
+ * @param {BusySignalService} [busySignalService]
+ * @return {Promise<*>} toolchain is ok
  */
 function checkToolchain(busySignalService) {
   return new Promise((resolve, reject) => {
     exec(`rustup run ${configToolchain()} rustc --version`)
       .then(resolve)
-      .catch(() => {
-        // If not found, install it
-        // Ask to install
-        atomPrompt(
-          `\`rustup\` missing ${configToolchain()} toolchain`,
-          {
-            detail: `rustup toolchain install ${configToolchain()}`
-          },
-          ["Install"]
-        ).then(response => {
-          if (response === "Install") {
-            let installPromise = installCompiler()
-              .then(checkToolchain)
-              .then(resolve)
-              .catch(e => {
-                console.warn(e)
-                clearIdeRustInfos()
-                let err = (e + '').split('\n')
-                err = err.length && err[0] || `Error installing rust  \`${configToolchain()}\``
-                atom.notifications.addError(err, {
-                  detail: 'Check the toolchain is valid & connection is available',
-                  dismissable: true
+      .catch(() => checkHasRls(configToolchain()).then(hasRls => {
+        // Toolchain not found, prompt to install
+        let toolchain = configToolchain()
+        const note = {
+          detail: `rustup toolchain install ${toolchain}`,
+          buttons: [{
+            text: 'Install',
+            onDidClick: () => {
+              clearIdeRustInfos()
+              let installPromise = installCompiler()
+                .then(checkToolchain)
+                .then(resolve)
+                .catch(e => {
+                  console.warn(e)
+                  clearIdeRustInfos()
+                  let err = (e + '').split('\n')
+                  err = err.length && err[0] || `Error installing rust  \`${toolchain}\``
+                  atom.notifications.addError(err, {
+                    detail: 'Check the toolchain is valid & connection is available',
+                    dismissable: true
+                  })
+                  resolve()
                 })
-                resolve()
-              })
 
-            if (busySignalService) {
-              busySignalService.reportBusyWhile(
-                `Installing rust \`${configToolchain()}\``,
-                () => installPromise
-              )
+              if (busySignalService) {
+                busySignalService.reportBusyWhile(
+                  `Installing rust \`${toolchain}\``,
+                  () => installPromise
+                )
+              }
             }
-          } else {
-            reject()
+          }]
+        }
+        const title = `\`rustup\` missing ${toolchain} toolchain`
+
+        if (hasRls) {
+          atomPrompt(title, note)
+        }
+        else {
+          delete note.detail
+          note.description = '**Warning**: This toolchain is missing Rls, or is unavilable.'
+          if (toolchain === 'nightly') {
+            note.description += ' Try using a previous _dated_ nightly.'
           }
-        })
-      })
-      .catch(() => {
-        // Missing rustup
-        // Ask to install
+          else if (toolchain.startsWith('nightly')) {
+            note.description += ' Try using another nightly version.'
+          }
+
+          note.buttons[0].className = 'btn-error'
+          fetchLatestDatedNightlyWithRls()
+            .catch(console.warn)
+            .then(version => {
+              if (version) {
+                note.buttons.push({
+                  text: `Use ${version}`,
+                  onDidClick: () => {
+                    clearIdeRustInfos()
+                    atom.config.set('ide-rust.rlsToolchain', version)
+                  }
+                })
+              }
+              atomPrompt(title, note)
+            })
+        }
+      }))
+      .catch(e => {
+        e && console.warn(e)
+        // Missing rustup, prompt to install
         atomPrompt(
           "`rustup` is not available",
           {
@@ -181,7 +187,10 @@ function checkToolchain(busySignalService) {
   .then(() => clearIdeRustInfos())
 }
 
-/** @param {string} [toolchain]  */
+/**
+ * @param {string} [toolchain]
+ * @return {object} environment vars
+ */
 function serverEnv(toolchain) {
   const env = { PATH: getPath() }
 
@@ -201,7 +210,8 @@ function serverEnv(toolchain) {
 
 /**
  * Check for and install Rls
- * @param [busySignalService]
+ * @param {BusySignalService} [busySignalService]
+ * @return {Promise<*>} rls installed
  */
 function checkRls(busySignalService) {
   let toolchain = configToolchain()
@@ -220,16 +230,37 @@ function checkRls(busySignalService) {
     // Don't have RLS
     let installRlsPromise = exec(`rustup component add rls-preview --toolchain ${toolchain}`)
       .catch(e => {
-        atom.notifications.addError(`\`rls-preview\` was not found on \`${toolchain}\``, {
-          detail: 'Try configuring another toolchain, like a previous nightly or `beta`',
+        if (toolchain.startsWith('nightly')) {
+          // 'rls-preview' not available search for a decent suggestion
+          return fetchLatestDatedNightlyWithRls()
+            .catch(console.warn)
+            .then(version => { throw [e, version] })
+        }
+        else throw [e]
+      })
+      .catch(e => {
+        let latestRlsNightly = e[1]
+
+        const note = {
+          detail: 'Try configuring another toolchain, like a dated nightly or `beta`',
           dismissable: true,
+          _src: 'ide-rust',
           buttons: [{
             text: 'Configure',
             onDidClick: () => atom.workspace.open('atom://config/packages/ide-rust')
           }]
-        })
-        e._logged = true
-        throw e
+        }
+        if (latestRlsNightly) {
+          note.buttons.push({
+            text: `Use ${latestRlsNightly}`,
+            onDidClick: () => atom.config.set('ide-rust.rlsToolchain', latestRlsNightly)
+          })
+        }
+
+        atom.notifications.addError(`\`rls-preview\` was not found on \`${toolchain}\``, note)
+
+        e[0]._logged = true
+        throw e[0]
       })
       .then(() => exec(`rustup component add rust-src --toolchain ${toolchain}`))
       .then(() =>
@@ -266,7 +297,7 @@ class RustLanguageClient extends AutoLanguageClient {
     this.config = {
       rlsToolchain: {
         description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
-          ' For example ***beta*** or ***nightly-2017-11-01***.',
+          ' For example ***beta*** or ***nightly-yyyy-mm-dd***.',
         type: 'string',
         default: 'nightly'
       },
@@ -285,11 +316,15 @@ class RustLanguageClient extends AutoLanguageClient {
 
   // check for toolchain updates if installed & not dated
   _promptToUpdateToolchain() {
-    const toolchain = configToolchain()
-    const datedRegex = /-\d{4,}-\d{2}-\d{2}$/
+    const confToolchain = configToolchain()
 
-    if (atom.config.get('ide-rust.checkForToolchainUpdates') && !datedRegex.test(toolchain)) {
-      checkForToolchainUpdates()
+    if (atom.config.get('ide-rust.checkForToolchainUpdates')) {
+      const dated = confToolchain.match(DATED_REGEX)
+      const toolchain = (dated ? dated[1] : confToolchain)
+
+      exec(`rustup run ${confToolchain} rustc --version`)
+        .then(({ stdout }) => fetchLatestDist({ toolchain, currentVersion: stdout }))
+        .catch(() => false)
         .then(newVersion => {
           if (newVersion) {
             atom.notifications.addInfo(`Rls \`${toolchain}\` toolchain update available`, {
@@ -297,11 +332,13 @@ class RustLanguageClient extends AutoLanguageClient {
               _src: 'ide-rust',
               dismissable: true,
               buttons: [{
-                text: 'Update',
+                text: confToolchain === toolchain ? 'Update' : 'Update & Switch',
                 onDidClick: () => {
                   clearIdeRustInfos()
 
-                  let updatePromise = exec(`rustup update ${toolchain}`)
+                  const updatePromise = exec(`rustup update ${toolchain}`)
+                    // set config in case going from dated -> latest
+                    .then(() => atom.config.set('ide-rust.rlsToolchain', toolchain))
                     .then(() => checkToolchain())
                     .then(() => checkRls())
                     .then(() => this._restartLanguageServers(`Updated Rls toolchain`))

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,107 +87,6 @@ function installCompiler() {
 }
 
 /**
- * Checks for rustup and nightly toolchain
- * If not found, asks to install. If user declines, throws error
- * @param {BusySignalService} [busySignalService]
- * @return {Promise<*>} toolchain is ok
- */
-function checkToolchain(busySignalService) {
-  return new Promise((resolve, reject) => {
-    exec(`rustup run ${configToolchain()} rustc --version`)
-      .then(resolve)
-      .catch(() => checkHasRls(configToolchain()).then(hasRls => {
-        // Toolchain not found, prompt to install
-        let toolchain = configToolchain()
-        const note = {
-          detail: `rustup toolchain install ${toolchain}`,
-          buttons: [{
-            text: 'Install',
-            onDidClick: () => {
-              clearIdeRustInfos()
-              let installPromise = installCompiler()
-                .then(checkToolchain)
-                .then(resolve)
-                .catch(e => {
-                  console.warn(e)
-                  clearIdeRustInfos()
-                  let err = (e + '').split('\n')
-                  err = err.length && err[0] || `Error installing rust  \`${toolchain}\``
-                  atom.notifications.addError(err, {
-                    detail: 'Check the toolchain is valid & connection is available',
-                    dismissable: true
-                  })
-                  resolve()
-                })
-
-              if (busySignalService) {
-                busySignalService.reportBusyWhile(
-                  `Installing rust \`${toolchain}\``,
-                  () => installPromise
-                )
-              }
-            }
-          }]
-        }
-        const title = `\`rustup\` missing ${toolchain} toolchain`
-
-        if (hasRls) {
-          atomPrompt(title, note)
-        }
-        else {
-          delete note.detail
-          note.description = '**Warning**: This toolchain is missing Rls, or is unavilable.'
-          if (toolchain === 'nightly') {
-            note.description += ' Try using a previous _dated_ nightly.'
-          }
-          else if (toolchain.startsWith('nightly')) {
-            note.description += ' Try using another nightly version.'
-          }
-
-          note.buttons[0].className = 'btn-error'
-          fetchLatestDatedNightlyWithRls()
-            .catch(console.warn)
-            .then(version => {
-              if (version) {
-                note.buttons.push({
-                  text: `Use ${version}`,
-                  onDidClick: () => {
-                    clearIdeRustInfos()
-                    atom.config.set('ide-rust.rlsToolchain', version)
-                  }
-                })
-              }
-              atomPrompt(title, note)
-            })
-        }
-      }))
-      .catch(e => {
-        e && console.warn(e)
-        // Missing rustup, prompt to install
-        atomPrompt(
-          "`rustup` is not available",
-          {
-            description: "From https://www.rustup.rs/",
-            detail: "curl https://sh.rustup.rs -sSf | sh"
-          },
-          ["Install"]
-        ).then(response => {
-          if (response === "Install") {
-            // Install rustup and try again
-            installRustup()
-              .then(checkToolchain)
-              .then(resolve)
-              .catch(reject)
-          } else {
-            reject()
-          }
-        })
-      })
-  })
-  .then(() => clearIdeRustInfos())
-}
-
-/**
  * @param {string} [toolchain]
  * @return {object} environment vars
  */
@@ -339,7 +238,7 @@ class RustLanguageClient extends AutoLanguageClient {
                   const updatePromise = exec(`rustup update ${toolchain}`)
                     // set config in case going from dated -> latest
                     .then(() => atom.config.set('ide-rust.rlsToolchain', toolchain))
-                    .then(() => checkToolchain())
+                    .then(() => this._checkToolchain())
                     .then(() => checkRls())
                     .then(() => this._restartLanguageServers(`Updated Rls toolchain`))
                     .catch(e => console.error(e))
@@ -357,6 +256,112 @@ class RustLanguageClient extends AutoLanguageClient {
         })
         .catch(e => console.error(e))
     }
+  }
+
+  /**
+   * Checks for rustup and nightly toolchain
+   * If not found, asks to install. If user declines, throws error
+   * @param {BusySignalService} [busySignalService]
+   * @return {Promise<*>} toolchain is ok
+   */
+  _checkToolchain(busySignalService) {
+    return new Promise((resolve, reject) => {
+      exec(`rustup run ${configToolchain()} rustc --version`)
+        .then(resolve)
+        .catch(() => checkHasRls(configToolchain()).then(hasRls => {
+          // Toolchain not found, prompt to install
+          let toolchain = configToolchain()
+          const title = `\`rustup\` missing ${toolchain} toolchain`
+
+          if (hasRls) {
+            atomPrompt(title, {
+              detail: `rustup toolchain install ${toolchain}`,
+              buttons: [{
+                text: 'Install',
+                onDidClick: () => {
+                  clearIdeRustInfos()
+                  let installPromise = installCompiler()
+                    .then(() => this._checkToolchain())
+                    .then(() => this._restartLanguageServers(`Installed Rls toolchain`))
+                    .catch(e => {
+                      console.warn(e)
+                      clearIdeRustInfos()
+                      let err = (e + '').split('\n')
+                      err = err.length && err[0] || `Error installing rust  \`${toolchain}\``
+                      atom.notifications.addError(err, {
+                        detail: 'Check the toolchain is valid & connection is available',
+                        dismissable: true
+                      })
+                    })
+
+                  if (busySignalService) {
+                    busySignalService.reportBusyWhile(
+                      `Installing rust \`${toolchain}\``,
+                      () => installPromise
+                    )
+                  }
+                }
+              }],
+            })
+          }
+          else {
+            const note = {
+              description: '**Warning**: This toolchain is missing Rls, or is unavilable.',
+              buttons: [{
+                text: 'Configure',
+                onDidClick: () => atom.workspace.open('atom://config/packages/ide-rust')
+              }],
+            }
+
+            if (toolchain === 'nightly') {
+              note.description += ' Try using a previous _dated_ nightly.'
+            }
+            else if (toolchain.startsWith('nightly')) {
+              note.description += ' Try using another nightly version.'
+            }
+
+            fetchLatestDatedNightlyWithRls()
+              .catch(e => console.warn(e))
+              .then(version => {
+                if (version) {
+                  note.buttons.push({
+                    text: `Use ${version}`,
+                    className: 'btn-success',
+                    onDidClick: () => {
+                      clearIdeRustInfos()
+                      atom.config.set('ide-rust.rlsToolchain', version)
+                    }
+                  })
+                }
+                atomPrompt(title, note)
+              })
+          }
+        }))
+        .catch(e => {
+          e && console.warn(e)
+          // Missing rustup, prompt to install
+          atomPrompt(
+            "`rustup` is not available",
+            {
+              description: "From https://www.rustup.rs/",
+              detail: "curl https://sh.rustup.rs -sSf | sh"
+            },
+            ["Install"]
+          ).then(response => {
+            if (response === "Install") {
+              // Install rustup and try again
+              installRustup()
+                .then(() => this._checkToolchain())
+                .then(resolve)
+                .catch(reject)
+            } else {
+              reject()
+            }
+          })
+        })
+        .then(() => reject())
+    })
+    .then(() => clearIdeRustInfos())
   }
 
   activate() {
@@ -379,7 +384,7 @@ class RustLanguageClient extends AutoLanguageClient {
 
     this.disposables.add(atom.config.onDidChange('ide-rust.rlsToolchain',
       _.debounce(({ newValue }) => {
-        checkToolchain(this.busySignalService)
+        this._checkToolchain(this.busySignalService)
           .then(() => checkRls(this.busySignalService))
           .then(() => this._restartLanguageServers(`Switched Rls toolchain to \`${newValue}\``))
           .then(() => this._promptToUpdateToolchain())
@@ -441,13 +446,18 @@ class RustLanguageClient extends AutoLanguageClient {
       })
     }
 
-    return checkToolchain(this.busySignalService)
-      .then(toolchain => checkRls(this.busySignalService).then(() => toolchain))
-      .then(toolchain => {
-        return cp.spawn("rustup", ["run", configToolchain(), "rls"], {
+    return this._checkToolchain(this.busySignalService)
+      .then(() => checkRls(this.busySignalService))
+      .then(err => {
+        if (err) console.error(err)
+        let toolchain = configToolchain()
+        return cp.spawn("rustup", ["run", toolchain, "rls"], {
           env: serverEnv(toolchain),
           cwd: projectPath
         })
+      })
+      .catch(e => {
+        throw e || new Error("failed to start server")
       })
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const cp = require("child_process")
 const os = require("os")
 const path = require("path")
 const _ = require('underscore-plus')
-const { CompositeDisposable } = require('atom')
+const { CompositeDisposable, Disposable } = require('atom')
 const { AutoLanguageClient } = require("atom-languageclient")
 const RlsProject = require('./rls-project.js')
 const {
@@ -11,6 +11,9 @@ const {
   checkHasRls,
   DATED_REGEX,
 } = require('./dist-fetch')
+
+/** @type {number} interval between toolchain update checks, milliseconds */
+const PERIODIC_UPDATE_CHECK_MILLIS = 6 * 60 * 60 * 1000
 
 function getPath() {
   // Make sure the cargo directory is in PATH
@@ -370,6 +373,7 @@ class RustLanguageClient extends AutoLanguageClient {
     // Get required dependencies
     require("atom-package-deps").install("ide-rust", false)
 
+    // Watch rls.toml file changes -> update rls
     this.disposables.add(atom.project.onDidChangeFiles(events => {
       if (_.isEmpty(this.projects)) return
 
@@ -382,6 +386,7 @@ class RustLanguageClient extends AutoLanguageClient {
       }
     }))
 
+    // Watch config toolchain changes -> switch, install & update toolchains, restart servers
     this.disposables.add(atom.config.onDidChange('ide-rust.rlsToolchain',
       _.debounce(({ newValue }) => {
         this._checkToolchain(this.busySignalService)
@@ -391,7 +396,23 @@ class RustLanguageClient extends AutoLanguageClient {
       }, 1000)
     ))
 
-    this._promptToUpdateToolchain()
+    // watch config toolchain updates -> check for updates if enabling
+    this.disposables.add(atom.config.onDidChange('ide-rust.checkForToolchainUpdates',
+      ({ newValue: enabled }) => {
+        if (enabled) this._promptToUpdateToolchain()
+      }
+    ))
+
+    // check for updates (if enabled) every so often
+    let periodicUpdateTimeoutId
+    const periodicUpdate = () => {
+      this._promptToUpdateToolchain()
+      periodicUpdateTimeoutId = setTimeout(periodicUpdate, PERIODIC_UPDATE_CHECK_MILLIS)
+    }
+    this.disposables.add(new Disposable(() => {
+      clearTimeout(periodicUpdateTimeoutId)
+    }))
+    periodicUpdate()
   }
 
   deactivate() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,7 @@ function atomPrompt(message, options, buttons) {
 function checkForToolchainUpdates() {
   const toolchain = configToolchain()
 
-  return exec(`rustup run ${toolchain} rustc --version`).then(({
-    stdout
-  }) => {
+  return exec(`rustup run ${toolchain} rustc --version`).then(({ stdout }) => {
     return new Promise((resolve, reject) => {
       require("https")
         .get(`https://static.rust-lang.org/dist/channel-rust-${toolchain}.toml`, res => {

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -6,7 +6,7 @@ const _ = require('underscore-plus')
 /**
  * Container for references to a single Rls invocation
  * @param {ActiveServer} server
- * @param {() => [BusySignalService]} busySignalServiceFn
+ * @param {function} busySignalServiceFn `() => [BusySignalService]`
  */
 class RlsProject {
   constructor(server, busySignalServiceFn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,9 +94,9 @@
       "dev": true
     },
     "atom-languageclient": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.8.1.tgz",
-      "integrity": "sha1-UCzOt36vKB4g3aDwdSDCN5+Zrqk=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.8.2.tgz",
+      "integrity": "sha1-eCie44hR3t72hv5UwZTkOc8Lm1Q=",
       "requires": {
         "fuzzaldrin-plus": "0.6.0",
         "vscode-jsonrpc": "3.5.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.8.1",
+    "atom-languageclient": "^0.8.2",
     "atom-package-deps": "^4.6.1",
     "toml": "^2.3.3",
     "underscore-plus": "^1.6.6"


### PR DESCRIPTION
This pr enhances toolchain handling particularly to more gracefully deal with the lack of Rls in some nightlies.

## New Features
- Graceful handling of Rls being missing from the distribution
  * Warns before installing a rust version without Rls or when using an already installed one
  * Automatic detection of, and prompt to install, the latest working dated release
- Updates from dated toolchains are now enabled
- Checks for toolchain updates every 6 hours
- Checks for toolchain updates when enabling the _check for toolchain updates_ setting

## Other
- Some language server startup issues were fixed in atom-languageclient `0.8.2`
- Added jsdoc to the eslint list and tweaked the rules a little more

## Example
Initial startup experience using default `nightly` toolchain, but when the current nightly release is missing Rls.
![no-nightly-to-working](https://user-images.githubusercontent.com/2331607/35247777-9957f1ca-ffc3-11e7-81b7-8cd5d122582f.gif)

This is an improvement as 
- we don't bother to install the nightly missing Rls
- we suggest the latest dated nightly that includes Rls
- Later on when `nightly` gets back Rls users will receive prompts to update at startup.
