### PR TITLE
Set RUST_SRC_PATH correctly for dated toolchains

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,9 +178,7 @@ function checkRls(busySignalService) {
         throw e[0]
       })
       .then(() => exec(`rustup component add rust-src --toolchain ${toolchain}`))
-      .then(() =>
-        exec(`rustup component add rust-analysis --toolchain ${toolchain}`)
-      )
+      .then(() => exec(`rustup component add rust-analysis --toolchain ${toolchain}`))
       .catch(e => {
         if (!e._logged) {
           atom.notifications.addError(`\`rust-src\`/\`rust-analysis\` not found on \`${toolchain}\``, {
@@ -482,8 +480,7 @@ class RustLanguageClient extends AutoLanguageClient {
 
     return this._checkToolchain(this.busySignalService)
       .then(() => checkRls(this.busySignalService))
-      .then(err => {
-        if (err) console.error(err)
+      .then(() => {
         let toolchain = configToolchain()
         return cp.spawn("rustup", ["run", toolchain, "rls"], {
           env: serverEnv(toolchain),

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,16 @@ function installCompiler() {
 }
 
 /**
+ * @param {string} toolchain
+ * @return {string} `rustc --print sysroot` stdout
+ */
+function rustcSysroot(toolchain) {
+  return cp.execSync(`rustup run ${toolchain} rustc --print sysroot`, {
+    env: { PATH: getPath() }
+  }).toString().trim()
+}
+
+/**
  * @param {string} [toolchain]
  * @return {object} environment vars
  */
@@ -97,12 +107,15 @@ function serverEnv(toolchain) {
   const env = { PATH: getPath() }
 
   if (toolchain) {
-    let rustSrcPath = process.env.RUST_SRC_PATH || ""
-    if (rustSrcPath.length === 0) {
-      rustSrcPath = path.join(
-        os.homedir(),
-        ".rustup/toolchains/" + toolchain + "/lib/rustlib/src/rust/src/"
-      )
+    let rustSrcPath = process.env.RUST_SRC_PATH
+    if (!rustSrcPath) {
+      try {
+        rustSrcPath = path.join(rustcSysroot(toolchain), "/lib/rustlib/src/rust/src/")
+      }
+      catch (e) {
+        console.error("Failed to find sysroot", e)
+        return env
+      }
     }
     env.RUST_SRC_PATH = rustSrcPath
   }


### PR DESCRIPTION
This pr uses `rustc --print sysroot` to find the sysroot rather than toolchain name itself. This should help racer to work regardless of toolchain choice.