### PR TITLE
Improve rls console logging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,21 +115,18 @@ function serverEnv(toolchain) {
   }
 
   if (toolchain) {
-    let rustSrcPath = process.env.RUST_SRC_PATH
-    if (!rustSrcPath) {
-      try {
-        rustSrcPath = path.join(rustcSysroot(toolchain), "/lib/rustlib/src/rust/src/")
-      }
-      catch (e) {
-        console.error("Failed to find sysroot", e)
-        return env
-      }
+    try {
+      env.RUST_SRC_PATH = path.join(rustcSysroot(toolchain), "/lib/rustlib/src/rust/src/")
     }
-    env.RUST_SRC_PATH = rustSrcPath
+    catch (e) {
+      console.error("Failed to find sysroot", e)
+    }
   }
-
   return env
 }
+
+// ongoing promise
+let _checkingRls
 
 /**
  * Check for and install Rls
@@ -139,7 +136,9 @@ function serverEnv(toolchain) {
 function checkRls(busySignalService) {
   let toolchain = configToolchain()
 
-  return exec(`rustup component list --toolchain ${toolchain}`).then(results => {
+  if (_checkingRls) return _checkingRls
+
+  _checkingRls = exec(`rustup component list --toolchain ${toolchain}`).then(results => {
     const { stdout } = results
     if (
       stdout.search(/^rls-preview.* \((default|installed)\)$/m) >= 0 &&
@@ -205,6 +204,14 @@ function checkRls(busySignalService) {
 
     return installRlsPromise
   })
+
+  try {
+    return _checkingRls
+  }
+  finally {
+    let clearOngoing = () => _checkingRls = null
+    _checkingRls.then(clearOngoing).catch(clearOngoing)
+  }
 }
 
 class RustLanguageClient extends AutoLanguageClient {

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,15 @@ function rustcSysroot(toolchain) {
  * @return {object} environment vars
  */
 function serverEnv(toolchain) {
-  const env = { PATH: getPath() }
+  const env = {
+    PATH: getPath(),
+    RUST_BACKTRACE: '1',
+    RUST_LOG: process.env.RUST_LOG,
+  }
+
+  if (!env.RUST_LOG && atom.config.get('core.debugLSP')) {
+    env.RUST_LOG = 'rls=warn'
+  }
 
   if (toolchain) {
     let rustSrcPath = process.env.RUST_SRC_PATH


### PR DESCRIPTION
* Add rls env: RUST_BACKTRACE=1
* Add rls env: RUST_LOG=atom_process.env.RUST_LOG
* When core.debugLSP add rls env: RUST_LOG=rls=warn (if not already set)
* Avoid concurrent checkRls promises _(can cause update error messages)_
* Don't use parent process RUST_SRC_PATH, it's unlikely to be correct for a dated toolchain