### PR TITLE
Add customisable global Rls config + defer update checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rust language support for Atom-IDE, powered by the Rust Language Server (RLS).
  - Format on save (disabled by default, see `atom-ide-ui` settings)
  - Rls toolchain selection in package settings
  - Rls toolchain update checking at startup & every 6 hours thereafter
- - Global Rls configuration for `all_targets`, `all_features`
+ - Global Rls configuration for `all_targets`
  - Per-project Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
    ```toml
    # rls.toml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Rust language support for Atom-IDE, powered by the Rust Language Server (RLS).
  - Format on save (disabled by default, see `atom-ide-ui` settings)
  - Rls toolchain selection in package settings
  - Rls toolchain update checking at startup & every 6 hours thereafter
- - Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
+ - Global Rls configuration for `all_targets`, `all_features`
+ - Per-project Rls configuration using `rls.toml` file at project root, see [rls#configuration](https://github.com/rust-lang-nursery/rls#configuration)
    ```toml
    # rls.toml
    features = ["serde"]

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,12 +227,36 @@ class RustLanguageClient extends AutoLanguageClient {
         description: 'Sets the toolchain installed using rustup and used to run the Rls.' +
           ' For example ***beta*** or ***nightly-yyyy-mm-dd***.',
         type: 'string',
-        default: 'nightly'
+        default: 'nightly',
+        order: 1
       },
       checkForToolchainUpdates: {
-        description: 'Check on startup for toolchain updates, prompting to install if available',
+        description: 'Check on startup & periodically for toolchain updates, prompting to install if available',
         type: 'boolean',
-        default: true
+        default: true,
+        order: 2
+      },
+      rlsDefaultConfig: {
+        title: "Rls Default Configuration",
+        description: 'Configuration default sent to all Rls instances, overridden by project rls.toml configuration',
+        type: 'object',
+        collapsed: false,
+        properties: {
+          allTargets: {
+            title: "Check All Targets",
+            description: 'Equivalent to `cargo check --all-targets`',
+            type: 'boolean',
+            default: true,
+            order: 1
+          },
+          allFeatures: {
+            title: "Check All Features",
+            description: 'Equivalent to `cargo check --all-features`',
+            type: 'boolean',
+            default: false,
+            order: 2
+          }
+        }
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,24 +237,18 @@ class RustLanguageClient extends AutoLanguageClient {
         order: 2
       },
       rlsDefaultConfig: {
-        title: "Rls Default Configuration",
+        title: "Rls Configuration",
         description: 'Configuration default sent to all Rls instances, overridden by project rls.toml configuration',
         type: 'object',
         collapsed: false,
         properties: {
           allTargets: {
             title: "Check All Targets",
-            description: 'Equivalent to `cargo check --all-targets`',
-            type: 'boolean',
-            default: true,
-            order: 1
-          },
-          allFeatures: {
-            title: "Check All Features",
-            description: 'Equivalent to `cargo check --all-features`',
-            type: 'boolean',
-            default: false,
-            order: 2
+            description: 'Checks tests, examples & benches. Equivalent to `cargo check --all-targets`',
+            type: 'string',
+            default: "Rls Default",
+            order: 1,
+            enum: ["On", "Off", "Rls Default"]
           }
         }
       }
@@ -478,6 +472,11 @@ class RustLanguageClient extends AutoLanguageClient {
       ({ newValue: enabled }) => {
         if (enabled) this._promptToUpdateToolchain().catch(logErr)
       }
+    ))
+
+    // restart running servers if default config changes
+    this.disposables.add(atom.config.onDidChange('ide-rust.rlsDefaultConfig',
+      () => this._restartLanguageServers().catch(logErr)
     ))
 
     // check for updates (if enabled) every so often

--- a/lib/index.js
+++ b/lib/index.js
@@ -489,7 +489,7 @@ class RustLanguageClient extends AutoLanguageClient {
     this.disposables.add(new Disposable(() => {
       clearTimeout(periodicUpdateTimeoutId)
     }))
-    periodicUpdate()
+    this._periodicUpdate = periodicUpdate
 
     this.disposables.add(atom.commands.add(
       'atom-workspace',
@@ -545,6 +545,12 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
+    if (this._periodicUpdate) {
+      // if haven't started checking for updates yet start now
+      this._periodicUpdate()
+      delete this._periodicUpdate
+    }
+
     let cmdOverride = rlsCommandOverride()
     if (cmdOverride) {
       if (!this._warnedAboutRlsCommandOverride) {

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -122,11 +122,12 @@ class RlsProject {
 
   // Default Rls config according to package settings & Rls defaults
   defaultConfig() {
-    const conf = atom.config.get("ide-rust.rlsDefaultConfig")
-    return {
-      all_targets: !!conf.allTargets,
-      all_features: !!conf.allFeatures
+    const { allTargets } = atom.config.get("ide-rust.rlsDefaultConfig")
+    const rlsConfig = {}
+    if (allTargets === "On" || allTargets === "Off") {
+      rlsConfig.all_targets = allTargets === "On"
     }
+    return rlsConfig
   }
 }
 

--- a/lib/rls-project.js
+++ b/lib/rls-project.js
@@ -97,15 +97,15 @@ class RlsProject {
     })
   }
 
-  // Send rls.toml as `workspace/didChangeConfiguration` message (or empty/default if no rls.toml)
+  // Send rls.toml as `workspace/didChangeConfiguration` message (or default if no rls.toml)
   sendRlsTomlConfig() {
     let rlsTomlPath = path.join(this.server.projectPath, 'rls.toml')
 
     fs.readFile(rlsTomlPath, (err, data) => {
-      let config = {}
+      let config = this.defaultConfig()
       if (!err) {
         try {
-          config = toml.parse(data)
+          Object.assign(config, toml.parse(data))
         } catch (e) {
           console.warn(`Failed to read ${rlsTomlPath}`, e)
         }
@@ -118,6 +118,15 @@ class RlsProject {
       })
       this._lastSentConfig = config
     })
+  }
+
+  // Default Rls config according to package settings & Rls defaults
+  defaultConfig() {
+    const conf = atom.config.get("ide-rust.rlsDefaultConfig")
+    return {
+      all_targets: !!conf.allTargets,
+      all_features: !!conf.allFeatures
+    }
   }
 }
 


### PR DESCRIPTION
This pr brings the idea of global default Rls config that can be centrally modified. ~It also brings a change to the default behaviour as `all_targets` will be set to true by default. That's because I think test & example code should be checked by Rls by default, even though that isn't the case currently upstream.~ I changed my mind and instead the default will be the same as before - upstream Rls defaults.

![](https://user-images.githubusercontent.com/2331607/36844345-3faa37a6-1d4a-11e8-9c09-2772db25924e.png)

* Add global `all_targets` Rls config
* Defer initial toolchain update check until first Rls startup. This reduces package startup time + means you don't have to deal with rust toolchain updates if you're using atom for something other than rust (heaven forbid). This brings the startup time down to around ~60ms.
* Sort settings
