### PR TITLE
Test code provided by alexheretic to filter variable type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -578,6 +578,9 @@ class RustLanguageClient extends AutoLanguageClient {
     }
   }
 
+  // Extends the outline provider by filtering the type variable, which is s
+  // only used for local variables by RLS. This makes the outline view
+  // cleaner and more useful.
   provideOutlines() {
     let provide = super.provideOutlines()
     let superOutline = provide.getOutline

--- a/lib/index.js
+++ b/lib/index.js
@@ -577,6 +577,20 @@ class RustLanguageClient extends AutoLanguageClient {
       throw new Error("failed to start server: " + e)
     }
   }
+
+  provideOutlines() {
+    let provide = super.provideOutlines()
+    let superOutline = provide.getOutline
+
+    provide.getOutline = async (...args) => {
+      let outline = await superOutline.apply(this, args)
+      outline.outlineTrees = outline.outlineTrees
+        .filter(o => o.icon !== "type-variable")
+      return outline
+    }
+
+    return provide
+  }
 }
 
 module.exports = new RustLanguageClient()


### PR DESCRIPTION
This commit in combination with the [changes in RLS categorization](https://github.com/rust-lang-nursery/rls/pull/734) make the outline view more useful and fixes #58.  

These are three outlines for the RLS's [rustc.rs](https://github.com/rust-lang-nursery/rls/blob/master/src/build/rustc.rs) file. The first is the previous state where there are many local variables between methods, the second one just filters the local variables in RLS and the third uses the new categorization and filter variables on ide-rust. Notice methods and fields are now properly shown.
![image](https://user-images.githubusercontent.com/8060778/36942090-9d45bdf8-1f49-11e8-825a-958458dd8dd4.png)
