### PR TITLE
Add plain `rust` as an additional grammar scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -528,7 +528,7 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 
   getGrammarScopes() {
-    return ["source.rust"]
+    return ["source.rust", "rust"]
   }
   getLanguageName() {
     return "Rust"


### PR DESCRIPTION
Atom has [added](https://github.com/atom/atom/pull/16299) experimental support for a new parsing system called [Tree-sitter](https://github.com/tree-sitter/tree-sitter). There is a [rust parser](https://github.com/tree-sitter/tree-sitter-rust) for Tree-sitter and a new [Atom package](https://github.com/atom/language-rust) that uses that parser.

The Tree-sitter grammars use a different convention for scope names than the TextMate grammars. Language names are no longer abbreviated by "source.". This PR adds the simple scope name `rust` to the list of scopes that this package supports, so that we can use this package when editing rust code with Tree-sitter enabled.